### PR TITLE
fix: add unpadded init_data hashes to RVPS for bare metal SNP

### DIFF
--- a/templates/rvps-values-policies.yaml
+++ b/templates/rvps-values-policies.yaml
@@ -25,7 +25,7 @@ spec:
           {{`{{- $debugRawHash := fromConfigMap "imperative" "debug-initdata" "RAW_HASH" -}}`}}
           {{`{{- $rawHashPadded := printf "%s00000000000000000000000000000000" $rawHash -}}`}}
           {{`{{- $debugRawHashPadded := printf "%s00000000000000000000000000000000" $debugRawHash -}}`}}
-          {{`{{- $referenceValues := list (dict "name" "init_data" "expiration" "2027-12-12T00:00:00Z" "value" (list $pcr8Hash $debugPcr8Hash $rawHashPadded $debugRawHashPadded)) -}}`}}
+          {{`{{- $referenceValues := list (dict "name" "init_data" "expiration" "2027-12-12T00:00:00Z" "value" (list $pcr8Hash $debugPcr8Hash $rawHash $debugRawHash $rawHashPadded $debugRawHashPadded)) -}}`}}
           {{`{{- $pcrStash := (lookup "v1" "Secret" "trustee-operator-system" "pcr-stash") -}}`}}
           {{`{{- if $pcrStash -}}`}}
           {{`{{- $secretData := $pcrStash.data.json | base64dec | fromJson -}}`}}


### PR DESCRIPTION
## Summary

The RVPS init_data reference values only contain zero-padded (96-char) raw hashes, which breaks attestation on bare metal AMD SEV-SNP.

SNP and TDX store the init_data hash in different hardware fields with different sizes:

- **TDX** uses `mr_config_id` (48 bytes) → 32-byte SHA-256 hash is zero-padded to 48 bytes (96 hex chars) ✓
- **SNP** uses `host_data` (32 bytes) → SHA-256 hash is stored as-is, no padding (64 hex chars) ✗

The KBS SNP verifier confirms this in `deps/verifier/src/snp/mod.rs`:
- `regularize_data(hash, 32, "HOST_DATA", "SNP")` — expects 32 bytes
- `hex::encode(report.host_data)` — emits 64 hex chars as the `init_data` claim

The OPA policy `input.init_data in query_reference_value("init_data")` fails because the 64-char hash from SNP is not in the RVPS list that only has 96-char padded values.

## Fix

Add `$rawHash` and `$debugRawHash` (unpadded, 64-char) to the RVPS reference values alongside the existing padded versions. This supports both TDX (padded) and SNP (unpadded).

## Test plan

- [x] Deployed on bare metal AMD EPYC 9845 (Turin) with SEV-SNP
- [x] CPU attestation status changed from Warning to Affirming after fix
- [x] Verified init_data hash format: KBS reports 64 hex chars for SNP

🤖 Generated with [Claude Code](https://claude.com/claude-code)