### PR TITLE
feat: add configurable worker_count for KBS HTTP server

### DIFF
--- a/templates/kbs-config-map.yaml
+++ b/templates/kbs-config-map.yaml
@@ -9,6 +9,9 @@ data:
   kbs-config.toml: |
     [http_server]
     sockets = ["0.0.0.0:8080"]
+    {{- if .Values.kbs.workerCount }}
+    worker_count = {{ .Values.kbs.workerCount }}
+    {{- end }}
     insecure_http = false
     private_key = "/etc/https-key/tls.key"
     certificate = "/etc/https-cert/tls.crt"

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,13 @@ kbs:
   # exist in the trustee-operator-system namespace.
   extraSecrets: []
 
+  # Number of HTTP worker threads for the KBS server.
+  # If unset, the KBS binary defaults to one worker per logical CPU core,
+  # which can cause "too many open files" crashes on high-core-count systems
+  # where the container's nofile ulimit is lower than the worker count.
+  # Set this to a reasonable value (e.g., 4-8) on systems with many cores.
+  # workerCount: 4
+
   # NVIDIA GPU confidential computing configuration
   gpu:
     enabled: false


### PR DESCRIPTION
## Summary

On high-core-count systems (e.g., 160-core AMD EPYC 9845 with 320 logical threads), the KBS crashes on startup with "Too many open files".

The KBS uses actix-web, which defaults to one HTTP worker thread per logical CPU core (`std::thread::available_parallelism()`). With 320 threads, this creates 512 workers that exceed the container's default nofile ulimit (1024 soft / 2048 hard in CRI-O).

## Fix

Add an optional `kbs.workerCount` Helm value that maps to the `worker_count` field in the KBS `[http_server]` config section. The KBS binary already supports this field (`kbs/src/config.rs:41` and `kbs/src/api_server.rs:145-147` in openshift/trustee v1.1.0), but the chart did not expose it.

When set, the KBS uses the specified number of workers. When unset, the existing auto-detection behavior is preserved, maintaining backward compatibility for systems where the default works.

## Usage

```yaml
kbs:
  workerCount: 4
```

## Test plan

- [x] Tested on 160-core AMD EPYC 9845 (320 threads) — KBS crashed without fix, runs with `worker_count = 4`
- [x] Verified backward compatibility — omitting `workerCount` preserves existing behavior
- [x] Confirmed KBS logs show `starting 4 workers` when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)