### PR TITLE
feat: add firmware reference values ESO and RVPS integration

### DIFF
--- a/templates/firmware-refvals-eso.yaml
+++ b/templates/firmware-refvals-eso.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.kbs.baremetal.enabled }}
+---
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: firmware-refvals-eso
+  namespace: trustee-operator-system
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: {{ .Values.secretStore.name }}
+    kind: {{ .Values.secretStore.kind }}
+  target:
+    name: firmware-reference-values
+    template:
+      type: generic
+  dataFrom:
+  - extract:
+      key: 'secret/data/hub/firmwareReferenceValues'
+{{- end }}

--- a/templates/rvps-values-policies.yaml
+++ b/templates/rvps-values-policies.yaml
@@ -44,6 +44,30 @@ spec:
           {{`{{- $referenceValues = append $referenceValues (dict "name" "snp_pcr12" "expiration" "2027-12-12T00:00:00Z" "value" (list $pcr12)) -}}`}}
           {{`{{- $referenceValues = append $referenceValues (dict "name" "tdx_pcr12" "expiration" "2027-12-12T00:00:00Z" "value" (list $pcr12)) -}}`}}
           {{`{{- end -}}`}}
+          {{`{{- $firmwareStash := (lookup "v1" "Secret" "trustee-operator-system" "firmware-reference-values") -}}`}}
+          {{`{{- if $firmwareStash -}}`}}
+          {{`{{- $firmwareData := $firmwareStash.data -}}`}}
+          {{`{{- if $firmwareData.mr_td -}}`}}
+          {{`{{- $mrTdValues := ($firmwareData.mr_td | base64dec | fromJson) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "mr_td" "expiration" "2027-12-12T00:00:00Z" "value" $mrTdValues) -}}`}}
+          {{`{{- end -}}`}}
+          {{`{{- if $firmwareData.rtmr_1 -}}`}}
+          {{`{{- $rtmr1Values := ($firmwareData.rtmr_1 | base64dec | fromJson) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_1" "expiration" "2027-12-12T00:00:00Z" "value" $rtmr1Values) -}}`}}
+          {{`{{- end -}}`}}
+          {{`{{- if $firmwareData.rtmr_2 -}}`}}
+          {{`{{- $rtmr2Values := ($firmwareData.rtmr_2 | base64dec | fromJson) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_2" "expiration" "2027-12-12T00:00:00Z" "value" $rtmr2Values) -}}`}}
+          {{`{{- end -}}`}}
+          {{`{{- if $firmwareData.snp_launch_measurement -}}`}}
+          {{`{{- $snpLaunchValues := ($firmwareData.snp_launch_measurement | base64dec | fromJson) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "snp_launch_measurement" "expiration" "2027-12-12T00:00:00Z" "value" $snpLaunchValues) -}}`}}
+          {{`{{- end -}}`}}
+          {{`{{- if $firmwareData.xfam -}}`}}
+          {{`{{- $xfamValues := ($firmwareData.xfam | base64dec | fromJson) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "xfam" "expiration" "2027-12-12T00:00:00Z" "value" $xfamValues) -}}`}}
+          {{`{{- end -}}`}}
+          {{`{{- end -}}`}}
           - complianceType: mustonlyhave
             objectDefinition:
               apiVersion: v1

--- a/values.yaml
+++ b/values.yaml
@@ -67,6 +67,16 @@ kbs:
     # For Azure: Use https://global.acccache.azure.net/sgx/certification/v4/
     # For bare metal/Intel: Use https://api.trustedservices.intel.com/sgx/certification/v4/
     collateralService: "https://api.trustedservices.intel.com/sgx/certification/v4/"
+
+  # Bare metal attestation configuration
+  # Enables firmware reference value collection and enforcement
+  baremetal:
+    # Enable bare metal firmware reference values (Intel TDX / AMD SEV-SNP)
+    # When enabled, creates ExternalSecret to pull firmware measurements from Vault
+    # Requires firmware values pushed to secret/data/hub/firmwareReferenceValues
+    # See docs/firmware-reference-values.md in coco-pattern for collection workflow
+    enabled: false
+
 # Attestation token certificate configuration
 # Used when secretStore.backend is "none" (cert-manager generates certs)
 attestation:


### PR DESCRIPTION
## Overview

Enable bare metal attestation policy enforcement using firmware measurements (Intel TDX / AMD SEV-SNP) collected via veritas and stored in Vault.

This is **PR 2B** of Wave 2 (firmware hardening) from the bare metal attestation hardening plan.

## Changes

### New Template
📦 **templates/firmware-refvals-eso.yaml** - ExternalSecret (gated on `kbs.baremetal.enabled`)
- Pulls from `secret/data/hub/firmwareReferenceValues` in Vault
- Creates `firmware-reference-values` secret in `trustee-operator-system`
- sync-wave 1 (before RVPS policy)

### Modified Template
🔄 **templates/rvps-values-policies.yaml** - Add firmware reference value block
Reads `firmware-reference-values` secret and appends to RVPS ConfigMap:
- **mr_td**: TDX initial TD measurement (SHA-384)
- **rtmr_1**: TDX firmware + bootloader (SHA-384)
- **rtmr_2**: TDX kernel + initrd (SHA-384)
- **snp_launch_measurement**: SNP initial memory measurement (SHA-384)
- **xfam**: TDX extended feature mask (hex)

Each value is an array (supports multi-version via merged values). Conditionally appends only if key exists in secret.

### New Value
⚙️ **kbs.baremetal.enabled**: `false` (default off, enabled per-profile)
- Controls firmware ESO creation
- Enables bare metal-specific attestation features

## Integration Flow

1. Firmware values collected via `veritas` and pushed to Vault (`coco-pattern` PR 2A workflow)
2. ESO syncs from Vault → `firmware-reference-values` secret (sync-wave 1)
3. RVPS policy reads secret → builds `rvps-reference-values` ConfigMap (sync-wave 6)
4. Attestation policy enforces firmware checks using RVPS values (PR 2C)

## Backwards Compatibility

✅ **Fully backwards compatible:**
- ESO only created when `kbs.baremetal.enabled=true`
- RVPS block conditionally appends if secret exists
- No functional change when disabled
- Azure deployments unaffected

## Testing

Tested on bare metal cluster with:
- Firmware values collected via veritas
- Values pushed to Vault at `secret/data/hub/firmwareReferenceValues`
- ESO synced successfully
- RVPS ConfigMap contains firmware reference values

## Dependencies

- **Requires coco-pattern PR 2A** for firmware value collection workflow
- **Followed by PR 2C** for attestation policy enforcement

## Related

Part of Wave 2 (firmware hardening) from the bare metal attestation hardening roadmap.