### PR TITLE
feat: change firmware reference values to single JSON blob format

### DIFF
--- a/templates/rvps-values-policies.yaml
+++ b/templates/rvps-values-policies.yaml
@@ -46,26 +46,21 @@ spec:
           {{`{{- end -}}`}}
           {{`{{- $firmwareStash := (lookup "v1" "Secret" "trustee-operator-system" "firmware-reference-values") -}}`}}
           {{`{{- if $firmwareStash -}}`}}
-          {{`{{- $firmwareData := $firmwareStash.data -}}`}}
+          {{`{{- $firmwareData := $firmwareStash.data.json | base64dec | fromJson -}}`}}
           {{`{{- if $firmwareData.mr_td -}}`}}
-          {{`{{- $mrTdValues := ($firmwareData.mr_td | base64dec | fromJson) -}}`}}
-          {{`{{- $referenceValues = append $referenceValues (dict "name" "mr_td" "expiration" "2027-12-12T00:00:00Z" "value" $mrTdValues) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "mr_td" "expiration" "2027-12-12T00:00:00Z" "value" $firmwareData.mr_td) -}}`}}
           {{`{{- end -}}`}}
           {{`{{- if $firmwareData.rtmr_1 -}}`}}
-          {{`{{- $rtmr1Values := ($firmwareData.rtmr_1 | base64dec | fromJson) -}}`}}
-          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_1" "expiration" "2027-12-12T00:00:00Z" "value" $rtmr1Values) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_1" "expiration" "2027-12-12T00:00:00Z" "value" $firmwareData.rtmr_1) -}}`}}
           {{`{{- end -}}`}}
           {{`{{- if $firmwareData.rtmr_2 -}}`}}
-          {{`{{- $rtmr2Values := ($firmwareData.rtmr_2 | base64dec | fromJson) -}}`}}
-          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_2" "expiration" "2027-12-12T00:00:00Z" "value" $rtmr2Values) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "rtmr_2" "expiration" "2027-12-12T00:00:00Z" "value" $firmwareData.rtmr_2) -}}`}}
           {{`{{- end -}}`}}
           {{`{{- if $firmwareData.snp_launch_measurement -}}`}}
-          {{`{{- $snpLaunchValues := ($firmwareData.snp_launch_measurement | base64dec | fromJson) -}}`}}
-          {{`{{- $referenceValues = append $referenceValues (dict "name" "snp_launch_measurement" "expiration" "2027-12-12T00:00:00Z" "value" $snpLaunchValues) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "snp_launch_measurement" "expiration" "2027-12-12T00:00:00Z" "value" $firmwareData.snp_launch_measurement) -}}`}}
           {{`{{- end -}}`}}
           {{`{{- if $firmwareData.xfam -}}`}}
-          {{`{{- $xfamValues := ($firmwareData.xfam | base64dec | fromJson) -}}`}}
-          {{`{{- $referenceValues = append $referenceValues (dict "name" "xfam" "expiration" "2027-12-12T00:00:00Z" "value" $xfamValues) -}}`}}
+          {{`{{- $referenceValues = append $referenceValues (dict "name" "xfam" "expiration" "2027-12-12T00:00:00Z" "value" $firmwareData.xfam) -}}`}}
           {{`{{- end -}}`}}
           {{`{{- end -}}`}}
           - complianceType: mustonlyhave


### PR DESCRIPTION
## Summary
Change firmware-reference-values secret consumption from multi-key format to single JSON blob format, aligning with the pcrStash pattern and enabling values-secret.yaml.template integration.

## Problem
The original firmware reference values implementation used a multi-key format where each measurement (mr_td, rtmr_1, etc.) is a separate base64-encoded JSON array in the Kubernetes secret. This does not align with the established pattern used by other secrets in coco-pattern (pcrStash, kbsPublicKey, etc.) which use values-secret.yaml.template with `path:` references to local files.

## Changes

### templates/rvps-values-policies.yaml (lines 47-70)
**Before** (multi-key):
```
$firmwareData := $firmwareStash.data
$firmwareData.mr_td | base64dec | fromJson
$firmwareData.rtmr_1 | base64dec | fromJson
...
```

**After** (single JSON blob):
```
$firmwareData := $firmwareStash.data.json | base64dec | fromJson
$firmwareData.mr_td  (already an array, no inner fromJson needed)
$firmwareData.rtmr_1
...
```

The secret structure changes from:
- **Before**: Multiple top-level keys (mr_td, rtmr_1, rtmr_2, snp_launch_measurement, xfam), each individually base64-encoded JSON
- **After**: Single `json` key containing the full JSON object (one decode operation)

### templates/firmware-refvals-eso.yaml
**No changes required** - the ESO `extract` directive still works with a single `json` key:
```yaml
extract:
  json:
    key: json
```

## Companion Changes
This change requires updates in coco-pattern (PR #89):
- `scripts/collect-firmware-refvals.sh`: Full lifecycle script (pod launch, veritas collection, cleanup) saving to `~/.coco-pattern/firmware-reference-values.json`
- `values-secret.yaml.template`: Single-blob format with `path:` reference to local file
- `Makefile`: `make collect-firmware-refvals` and `make collect-firmware-refvals-merge` targets
- Documentation: Automated workflow guide

## Breaking Change
⚠️ **BREAKING CHANGE:** Existing deployments using firmware reference values must update their Vault secret structure.

**Migration:** Re-run the collection workflow from coco-pattern PR #89:
```bash
make collect-firmware-refvals
# Uncomment firmwareReferenceValues in ~/values-secret-coco-pattern.yaml
make load-secrets
```

The new script saves to `~/.coco-pattern/firmware-reference-values.json` and the values-secret template loads it as a single JSON blob to Vault.

## Testing
- [ ] Deploy on bare metal with new single-blob format
- [ ] Verify firmware-reference-values secret has `json` key
- [ ] Verify rvps-reference-values ConfigMap contains firmware entries
- [ ] Test attestation with firmware values

## Dependencies
- **Companion PR**: coco-pattern #89 (firmware collection automation)
- **Wiring PR**: coco-pattern #90 (bump chartVersion to 0.6.*)
- **Release**: trustee-chart v0.6.0 (BREAKING CHANGE requires major bump)

## Related
Part of Wave 2 (firmware hardening) from the bare metal attestation hardening roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)